### PR TITLE
A: vidapi.expepp.de (third-party)

### DIFF
--- a/german.txt
+++ b/german.txt
@@ -30,3 +30,6 @@ t-online.de##a.Tctiga[href^="https://t-online.de/-"]
 
 ! #11076
 ||glomex.com^$media,rewrite=abp-resource:blank-mp3,domain=player.glomex.com
+
+! MISC
+||vidapi.expepp.de^$third-party


### PR DESCRIPTION
added a german third-party media advertisor which circumvents ABP