### PR TITLE
Remove cloudfront.net dubes, now in Easylist

### DIFF
--- a/english.txt
+++ b/english.txt
@@ -217,12 +217,6 @@ justjared.com,pockettactics.com#$#abort-on-property-read PerformanceLongTaskTimi
 ||grlnpmbc.goar.justjared.com^$domain=justjared.com
 
 ! #10531
-||d12ysuoljjyfqa.cloudfront.net^$script,domain=thisisfutbol.com
-||d1oxccu2k3w6jx.cloudfront.net^$script,domain=footballtransfertavern.com
-||dlkfm8bqz0bpx.cloudfront.net^$script,domain=footballleagueworld.co.uk
-||d1lu68kpg9miy0.cloudfront.net^$script,domain=celticquicknews.co.uk
-||d11a2fzhgzqe7i.cloudfront.net^$script,domain=thecelticblog.com
-||d3pk579obpqv7b.cloudfront.net^$script,domain=videocelts.com
 ||1m4s7a9.jba.tribunnews.com^$script,xmlhttprequest,domain=tribunnews.com
 ||x2py3z.kgy.pockettactics.com^$domain=pockettactics.com
 ||d2kz60b0gq4lg.cloudfront.net^$script,domain=psychologyjunkie.com


### PR DESCRIPTION
`thisisfutbol.com`
https://github.com/easylist/easylist/commit/64ab906b61dc8e8aa71334ca85bfc08505dc486c
`footballtransfertavern.com`
https://github.com/easylist/easylist/commit/a761fa99678ea0598010231f980723630a0476ba
`footballleagueworld.co.uk`
https://github.com/easylist/easylist/commit/09fce829b662a549c9393f2955a76d74d304d0e2
`celticquicknews.co.uk`
https://github.com/easylist/easylist/commit/2c87e3bee698a9ddecaa7baf4a3b50f33e270679
`thecelticblog.com`
https://github.com/easylist/easylist/commit/c784c16fa207b43df3969bfe714275632356e6ff
`videocelts.com`
https://github.com/easylist/easylist/commit/191aa0e26e3914272be456a7c9d4fd3de7774d91