### PR TITLE
Prevent ads from loading through first-party items

### DIFF
--- a/english.txt
+++ b/english.txt
@@ -174,6 +174,7 @@ swatchseries.to#$#abort-on-property-read zfgloadednative
 
 ! #18552
 9to5google.com,9to5mac.com,9to5toys.com,electrek.co#$#abort-on-property-read canRunAds
+9to5google.com,9to5mac.com,9to5toys.com,electrek.co#$#abort-on-property-read $aproxy
 
 ! #16818
 dailymail.co.uk##.billboard


### PR DESCRIPTION
Wasn't sure where to stick this, so I put it under the exisiting 9to5google filters.

Without this filter, ads will be loaded from this site. (Using some 3rd-party->1st-party hooks) to show the ads. 