### PR TITLE
Fix popup ads on vidop / vev / vidup

### DIFF
--- a/english.txt
+++ b/english.txt
@@ -288,6 +288,7 @@ igg-games.com#$#abort-on-property-write btoa
 porn.com,hotmovs.com,rule34hentai.net#$#abort-on-property-read open
 xhamster.com#$#abort-on-property-read wig-popunder
 marketrealist.com#$#abort-on-property-read adHandler.cmd.push
+vev.io,vev.red,vidop.icu,vidup.io#$#abort-current-inline-script window.__INITIAL_STATE__
 
 ! #10530
 extreme-d0wn.com,extreme-d0wn.net,extreme-down.in,extreme-down.one,extreme-down.pro,extreme-download.club,extreme-download.me,ffmovies.ru,123movies2019.com,gomovies.film,gomovies.sc,gomovies.pl,gomovies.es,gomovieshub.io,gostream.nu,openloadmovies.net,openloadmovies.review,vidsrc.me,serieslatinoamerica.com,movies123.xyz,bonstreams.net,txcmp3.com,streamcloud.eu,yifyddl.movie,yts.am,keeplinks.co,hdonline.video,convert2mp3.net,flashx.pw,flashx.tv,cloudvideo.tv,gogoanime.cloud,tv-onlinehd.com,revivelink.com#$#abort-on-property-read atob
@@ -329,6 +330,3 @@ $popup,third-party,domain=streamega.com|123putlocker.club|mstream.rocks|openload
 ! #19788
 bing.com##li.b_adBottom
 bing.com###b_results > li:not(.b_algo):not(.b_ans):not(.b_pag):not(.aca_algo):not(.aca_algo_count):not(.b_msg)
-
-! vidop / vev.red
-vev.io,vev.red,vidop.icu,vidup,io#$#abort-current-inline-script window.__INITIAL_STATE__

--- a/english.txt
+++ b/english.txt
@@ -329,3 +329,6 @@ $popup,third-party,domain=streamega.com|123putlocker.club|mstream.rocks|openload
 ! #19788
 bing.com##li.b_adBottom
 bing.com###b_results > li:not(.b_algo):not(.b_ans):not(.b_pag):not(.aca_algo):not(.aca_algo_count):not(.b_msg)
+
+! vidop / vev.red
+vev.io,vev.red,vidop.icu,vidup,io#$#abort-current-inline-script window.__INITIAL_STATE__


### PR DESCRIPTION
This a popup ad script, blocking the following will prevent a full window from popping up. 

vev and vidop, vidup are mirrors of the same domains:

`https://vev.red/qnoxpkl5lm30`
`https://vidop.icu/y6w1glonjw1q`