### PR TITLE
Anti-adblock detection on dictionary.com & thesaurus.com

### DIFF
--- a/english.txt
+++ b/english.txt
@@ -376,3 +376,6 @@ realgfporn.com#$#abort-on-property-read encodeURI
 $popup,third-party,domain=streamega.com|123putlocker.club|mstream.rocks|openloadmovies.bz
 ||35.194.16.41^$popup
 /favicon.ico$popup,domain=vidshare.tv
+
+! thesaurus.com / dictionary.com Adblock detection
+dictionary.com,thesaurus.com#$#abort-on-property-read adDetection


### PR DESCRIPTION
From `https://www.dictionary.com/`and `https://www.thesaurus.com/`

Blocking adDetection property from `https://www.dictionary.com/hp-assets/ads.js`

Unsure if this actually being active being tested.

Similarly landed https://github.com/uBlockOrigin/uAssets/pull/7028