### PR TITLE
Additional Fixes for youtube.com

### DIFF
--- a/english.txt
+++ b/english.txt
@@ -337,3 +337,4 @@ thetrendspotter.net,theavtimes.com#$#abort-on-property-read advads_passive_ads
 
 ! #CV-782
 youtube.com#$#json-prune 'playerResponse.adPlacements playerResponse.playerAds adPlacements playerAds'
+youtube.com#$#override-property-read adPlacements undefined; override-property-read ytInitialPlayerResponse.adPlacements undefined

--- a/english.txt
+++ b/english.txt
@@ -337,4 +337,4 @@ thetrendspotter.net,theavtimes.com#$#abort-on-property-read advads_passive_ads
 
 ! #CV-782
 youtube.com#$#json-prune 'playerResponse.adPlacements playerResponse.playerAds adPlacements playerAds'
-youtube.com#$#override-property-read adPlacements undefined; override-property-read ytInitialPlayerResponse.adPlacements undefined
+youtube.com#$#override-property-read playerResponse.adPlacements undefined; override-property-read ytInitialPlayerResponse.adPlacements undefined


### PR DESCRIPTION
This helps preventing the famous `White Screen` unskippable ad issue being experienced by a us and other adblockers.  Will be applicable with ABP 3.9.4 release.

![image_from_ios](https://user-images.githubusercontent.com/1659004/89651968-dbe6cd00-d918-11ea-9b85-810b152e03be.jpg)

Related fixes I also rolled out: https://github.com/brave/adblock-lists/pull/432  & https://github.com/brave/adblock-lists/pull/420


