### PR TITLE
Cover domain youtube-nocookie.com in youtube snippet

### DIFF
--- a/english.txt
+++ b/english.txt
@@ -338,5 +338,5 @@ topwwnews.com#$#abort-on-property-read localStorage
 thetrendspotter.net,theavtimes.com#$#abort-on-property-read advads_passive_ads
 
 ! #CV-782
-youtube.com#$#json-prune 'playerResponse.adPlacements playerResponse.playerAds adPlacements playerAds'
-youtube.com#$#override-property-read playerResponse.adPlacements undefined; override-property-read ytInitialPlayerResponse.adPlacements undefined
+youtube.com,youtube-nocookie.com#$#json-prune 'playerResponse.adPlacements playerResponse.playerAds adPlacements playerAds'
+youtube.com,youtube-nocookie.com#$#override-property-read playerResponse.adPlacements undefined; override-property-read ytInitialPlayerResponse.adPlacements undefined


### PR DESCRIPTION
Just to sync with other filters, https://github.com/uBlockOrigin/uAssets/pull/7756 and https://github.com/brave/adblock-lists/pull/442

Used `https://www.youtube-nocookie.com/embed/JwV1iWE8xY0`

and embeded: `https://www.racingcircuits.info/europe/norway/arctic-circle-raceway.html#.XzMw2CiA4uX`

We should also cover `youtube-nocookie.com` domain for our current youtube snippets. 