### PR TITLE
Update search.seznam.cz filter in czech.txt

### DIFF
--- a/czech.txt
+++ b/czech.txt
@@ -354,7 +354,7 @@ clanky.seznam.cz,search.seznam.cz##.Result-ico:not([class="Result-ico"])
 clanky.seznam.cz,search.seznam.cz##.Result.Result--organic > .Result-ico:not([class="Result-ico"]) + .Result-contentContainer
 clanky.seznam.cz,search.seznam.cz#?#:-abp-has(> .Result--organic .Result-title-link:not([class="Result-title-link"]))
 clanky.seznam.cz,search.seznam.cz#?#.Result:-abp-has(.Result--organic [class^="Result-contentContainer _"])
-clanky.seznam.cz,search.seznam.cz#?#.Result.Result--organic:-abp-has(.Result-title + .Result-contentContainer > :not(.Result-url) > :not([class="Result-url-link Result-url-link--cr-result"]):not(span):not(.AnchorList-list))
+clanky.seznam.cz,search.seznam.cz#?#.Result.Result--organic:-abp-has(.Result-title + .Result-contentContainer > :not(.Result-url):not(.Result-dw-wrapper) > :not([class="Result-url-link Result-url-link--cr-result"]):not(span):not(.AnchorList-list))
 
 ! MISC
 info.cz,lupa.cz,karaoketexty.cz,hnonline.sk#$#abort-current-inline-script Math.random adb


### PR DESCRIPTION
A new non-ad element `.Result-dw-wrapper` may appear to some users, which causes the whole organic result `.Result.Result--organic` to get blocked by this filter.
![Snímek obrazovky 2020-10-01 v 11 10 46](https://user-images.githubusercontent.com/9162439/94790780-0d3ebf00-03d7-11eb-9e5c-afd55ef845f3.png)
