### PR TITLE
Counter FLoC checks

### DIFF
--- a/english.txt
+++ b/english.txt
@@ -353,5 +353,8 @@ agronews.ua,aegeanews.gr,batterypoweronline.com,brezovycukr.cz,centrocommerciale
 ! #CV-899
 crunchyroll.com#$#json-prune 'value.media.ad_breaks'
 
+! Fix FloC checks on Chrome https://amifloced.org/
+*#$#override-property-read Document.prototype.interestCohort undefined
+
 ! #CV-776
 bing.com##[id$="adsMvCarousel"]


### PR DESCRIPTION
Already implemented by [Brave](https://github.com/brave/brave-browser/issues/14942), [uBO](https://github.com/uBlockOrigin/uBlock-issues/issues/1553), [Adguard](https://github.com/AdguardTeam/AdguardFilters/commit/f7b82b5c02e85d98560ddc1fcea5297e341d535d), [Duckduckgo](https://www.ghacks.net/2021/04/10/duckduckgo-extension-blocks-google-floc-in-latest-update/)

`*##+js(set, document.interestCohort, undefined)` which became more specific `Document.prototype.interestCohort` (Thanks Adguard)

Test case: `https://amifloced.org/` But will eventually occur on various sites.

Given it's supported by other Adblock extensions, for privacy, it should also be covered by ABP


