### PR TITLE
A: #FDA-2332

### DIFF
--- a/english.txt
+++ b/english.txt
@@ -364,3 +364,6 @@ crunchyroll.com#$#json-prune 'value.media.ad_breaks'
 ! #CV-776
 bing.com##[id$="adsMvCarousel"]
 bing.com#?#li[class="b_algo"]:-abp-has(> h2 + div[class="b_caption"] > p[class])
+
+! #FDA-2332
+mediafire.com#$#abort-current-inline-script isWithinRect Pop


### PR DESCRIPTION
#FDA-2332
Adds: `mediafire.com#$#abort-current-inline-script isWithinRect Pop` to block redirect popup ton [mediafire.com](https://www.mediafire.com/file/6m8n6glpk0qvfgm/coral-egan-deep-in-my-heart-cybersix-opening.mp4/file) triggered after clicking on the **Download** button.