### PR TITLE
A: FDA-2401

### DIFF
--- a/english.txt
+++ b/english.txt
@@ -314,6 +314,7 @@ filecrypt.cc,filecrypt.co#$#abort-on-property-read isAdblock
 hclips.com#$#abort-on-property-read adver
 txxx.com#$#override-property-read skpPop true; abort-on-property-read ExoLoader; abort-on-property-read open
 protonvideo.to#$#abort-on-property-read PlayerjsEvents
+manga18fx.com#$#abort-on-property-read document.querySelectorAll popmagicldr
 
 *$popup,third-party,domain=streamega.com|123putlocker.club|openloadmovies.bz
 about:blank$popup,domain=streamtape.cc|streamtape.net|streamtape.xyz|streamtape.com|strtapeadblock.me


### PR DESCRIPTION
Popup redirect to some NSFW websites after clicking on any chapter on [manga18fx](https://manga18fx.com/manga/secret-class)
Filter that blocks script is already in EL: **||realsrv.com^** and` ||realsrv.com^$popup `but seem not enough to block redirects.

Adding `manga18fx.com#$#abort-on-property-read document.querySelectorAll popmagicldr`

Please feel free to change it accordingly or for below one that also works:
`manga18fx.com#$#abort-on-property-read document.querySelectorAll popMagic`

<img width="1120" alt="m1f" src="https://user-images.githubusercontent.com/57706597/129542602-bcfd2490-6725-4e82-833c-36e665ed2248.png">
