### PR TITLE
A: hentai20.com

### DIFF
--- a/english.txt
+++ b/english.txt
@@ -275,7 +275,7 @@ youdbox.com#$#abort-on-property-read encodeURIComponent
 nosteam.ro#$#abort-on-property-write jsPop21
 manganelo.tv#$#abort-on-property-read document.createElement
 1piecemanga.com#$#abort-on-property-read document.createElement
-manga18fx.com#$#abort-on-property-read document.getElementsByTagName
+manga18fx.com,hentai20.com#$#abort-on-property-read document.getElementsByTagName
 
 ! #CV-667
 gomovies.film,gomovies.sc,gomovies.es,gomovieshub.io,openloadmovies.net,openloadmovies.review,vidsrc.me,movies123.xyz,bonstreams.net,yts.am,keeplinks.co,flashx.pw,flashx.tv,cloudvideo.tv,gogoanime.cloud,revivelink.com#$#abort-on-property-read atob


### PR DESCRIPTION
Filter adjustment - just added domain: **hentai20.com** to rule: `manga18fx.com#$#abort-on-property-read document.getElementsByTagName`
 
Is the same  case as my previsous PR [#667](https://github.com/abp-filters/abp-filters-anti-cv/pull/667) where EL filters: `||realsrv.com^` and` ||realsrv.com^$popup` are not enough to block redirect popups and even the script is the same.

<img width="1392" alt="hentai" src="https://user-images.githubusercontent.com/57706597/129704678-b8eaa9d9-32ca-4451-b24d-810254f8a38e.png">



