### PR TITLE
Fix Facebook video playback exiting

### DIFF
--- a/english.txt
+++ b/english.txt
@@ -82,7 +82,6 @@ www.facebook.com##div[data-pagelet="RightRail"] a[aria-labelledby][target="_blan
 www.facebook.com#$#hide-if-matches-xpath './/object[@type="nested/pressable"]/a[@role="link"]/span[contains(text(),"Patrocinado") or contains(text(),"Sponsa") or contains(text(),"Bersponsor") or contains(text(),"Commandité") or contains(text(),"Ditaja") or contains(text(),"Gesponsert") or contains(text(),"Gesponsord") or contains(text(),"Patrocinado") or contains(text(),"Publicidad") or contains(text(),"Sponsa") or contains(text(),"Sponset") or contains(text(),"Sponsored") or contains(text(),"Sponsorisé") or contains(text(),"Sponsorizat") or contains(text(),"Sponsorizzato") or contains(text(),"Sponsorlu") or contains(text(),"Sponsorowane") or contains(text(),"Реклама") or contains(text(),"ממומן") or contains(text(),"تمويل شوي") or contains(text(),"دارای پشتیبانی مالی") or contains(text(),"سپانسرڈ") or contains(text(),"مُموَّل") or contains(text(),"प्रायोजित") or contains(text(),"সৌজন্যে") or contains(text(),"ได้รับการสนับสนุน") or contains(text(),"内容") or contains(text(),"贊助") or contains(text(),"Sponsoroitu") or text()="May Sponsor" or text()="Được tài trợ"]/ancestor::span[2]'
 
 ! Filipino
-www.facebook.com#$#hide-if-matches-xpath './/span[@class][@dir="auto"]/span[@class][not(@style) and not(@id)][text()="Mag-apply Na" or text()="Mag-sign Up" or text()="Mamili Na" or text()="Mag-book Na" or text()="Alamin Pa" or text()="Kontakin Kami"]/ancestor::div[starts-with(@data-pagelet,"FeedUnit_")]'
 
 ! #CV-241
 swatchseries.to#$#abort-on-property-read zfgloadednative


### PR DESCRIPTION
When a ad is inserted into a video, it'll attempt and then fail the video advert and completely remove the video content for the user. 

Removing the problematic rule for the timebeing (or unless it can be tweaked to avoid this from happening)

Sample captures of the issue:

https://gif.fanboy.co.nz/gif/facebook-issue.gif

https://gif.fanboy.co.nz/gif/facebook-issue2.gif