### PR TITLE
kiuruvesilehti.fi & urjalansanomat.fi scrolling limitation removal

### DIFF
--- a/finnish.txt
+++ b/finnish.txt
@@ -1,0 +1,1 @@
+kiuruvesilehti.fi,urjalansanomat.fi#$#abort-current-inline-script cm_limit


### PR DESCRIPTION
Hi, I don't know whether you accept this or not but on these sites, when cookies are not accepted, they will limit your scrolling so that you can only scroll and view small part of the site.

`https://kiuruvesilehti.fi/`
`https://urjalansanomat.fi/`

Script responsible for this behavior:

```
function cm_limit(elh) {
	window.scrollTo(0,0);
	var vh = window.innerHeight;
	if (vh > elh) elh = vh;
	cm_elh = elh;
	var doc = document.documentElement;
	window.addEventListener('scroll',function(e) {
		var vh = window.innerHeight;
		var allow = cm_elh; /* - vh + 0; */
		var top = (window.pageYOffset || doc.scrollTop)  - (doc.clientTop || 0);
		if (top > allow) 
			window.scrollTo(0, allow);
	});
}
```