### PR TITLE
A: MISC

### DIFF
--- a/portuguese.txt
+++ b/portuguese.txt
@@ -10,6 +10,7 @@ anitube.be,anitube.cx,anitube.cz#$#abort-on-property-write _pop
 ||torcidatricolor.tv/*.gif$image
 kastream.biz#$#abort-on-property-write open
 filmesonlinegratis.com#$#abort-on-property-read atob
+multicanais.tv#$#abort-current-inline-script document.createElement _whvbtwzo
 
 ! #CV-667
 filmesonlinegratis.com#$#abort-current-inline-script Math zfgloaded


### PR DESCRIPTION
Adds: `multicanais.tv#$#abort-current-inline-script document.createElement _whvbtwzo` to block redirects on [/multicanais.tv/](https://multicanais.tv/tvaovivo/) some rules from EL such as: `||stawhoph.com^` seem not enough to block the other popups.

Informed PTFLA to add: `||multicanais.tv/wp-content/uploads/2021/07/MULTICANAIS-TV-ONLINE.png$popup` to block popup when you click on any article.
<img width="1048" alt="ca" src="https://user-images.githubusercontent.com/57706597/139035032-e849e513-7bc7-4373-ac54-7cfa78ab3206.png">

