### PR TITLE
A: MISC

### DIFF
--- a/russian.txt
+++ b/russian.txt
@@ -94,7 +94,7 @@ sound-park.rocks,sound-park.world,soundpark.rocks#$#abort-current-inline-script 
 shaiba.kz#$#abort-current-inline-script $ 1xbet
 liveforums.ru#$#abort-on-property-read tnAdditionalParams
 musify.club#$#abort-current-inline-script $ get_ya_browser
-mp3spy.cc#$#abort-current-inline-script JSON.parse atob
+mp3spy.cc,cinevision.online#$#abort-current-inline-script JSON.parse atob
 tagaev.com#$#abort-on-property-read PUM
 l2top.ru#$#abort-current-inline-script $ cleanAndEval
 rsload.net#$#abort-current-inline-script window.addEventListener load


### PR DESCRIPTION
Added domain **cinevision.online** to existing rule: `mp3spy.cc#$#abort-current-inline-script JSON.parse atob` in order to block redirect popup on https://cinevision.online (click on any title and pop up comes up).

Another rule that seems to work is: `cinevision.online#$#abort-current-inline-script document.createElement _faajx`
in case is not posisble to add  this domain to the russian.txt file.

<img width="944" alt="p91" src="https://user-images.githubusercontent.com/57706597/139082580-d1b97b11-1125-410a-81b4-611b49b55ca0.png">
<img width="1266" alt="p92" src="https://user-images.githubusercontent.com/57706597/139082591-5843525b-689c-41fc-9409-5841cce4ac4b.png">


