### PR TITLE
A: MISC

### DIFF
--- a/english.txt
+++ b/english.txt
@@ -313,7 +313,7 @@ srsone.top#$#override-property-read googlecx noopFunc
 animepahe.ru,animepahe.org,animepahe.com#$#abort-on-property-read document.querySelector
 mediafire.com#$#abort-current-inline-script isWithinRect Pop
 *$popup,third-party,domain=streamega.com|123putlocker.club|openloadmovies.bz
-about:blank$popup,domain=streamtape.cc|streamtape.net|streamtape.xyz|streamtape.com|strtapeadblock.me
+about:blank$popup,domain=streamtape.cc|streamtape.net|streamtape.xyz|streamtape.com|strtapeadblock.me|slreamplay.cc|streamta.pe|hd-full.cc|mixdrop.co|animeflv.cc
 /favicon.ico$popup,domain=vidshare.tv|vudeo.net
 ||35.194.16.41^$popup
 ||gadsims.com^$popup


### PR DESCRIPTION
Adding domains: **slreamplay.cc|streamta.pe|hd-full.cc|mixdrop.co|animeflv.cc** to an existing rule: `about:blank$popup,domain=`

### **Websites**
1 - https://hd-full.cc/pelicula/safer-at-home

Server options: **Streamplay.to** and **Streamtape.com**
* Added: slreamplay.cc|streamta.pe
<img width="1233" alt="hdc" src="https://user-images.githubusercontent.com/57706597/140169512-166f2024-f4d5-45e5-a4b2-0367ea4c9fc1.png">


Server option: **mixdrop.co**
* Added: hd-full.cc|mixdrop.co
<img width="1184" alt="hda" src="https://user-images.githubusercontent.com/57706597/140169574-f7034668-ea7d-48c7-bf46-b47907d47757.png">



2 -https://ww3.animeflv.cc/deep-insanity-the-lost-child-4

**Opcion 1** > **Xstreamcdn** and **Streamtape**
* Added: animeflv.cc
<img width="1130" alt="anflv" src="https://user-images.githubusercontent.com/57706597/140169646-588639e3-3faa-4ab3-859e-f3fc56dd4cee.png">



> Please note that domain: **streamta.pe** is already in ELSpanish: `$popup,third-party,domain=divxtotal.co` but perhaps would be good to also have it in the anti-cv list, to cover other lists.
> 
> Similar case for domain: **mixdrop.co** already in EL: `|about:blank#$popup,domain=` but rule seems not enough to block it.
