### PR TITLE
A: [NSFW] comicsporno.xxx

### DIFF
--- a/spanish.txt
+++ b/spanish.txt
@@ -26,3 +26,4 @@ jkanime.net#$#abort-current-inline-script Math break
 animefenix.com#$#abort-current-inline-script document.createElement _yzvesi
 pelisplus.so#$#abort-on-property-write _zoxxpiee
 iguarras.com,iputitas.net#$#abort-on-property-read afScript
+comicsporno.xxx

--- a/spanish.txt
+++ b/spanish.txt
@@ -26,4 +26,4 @@ jkanime.net#$#abort-current-inline-script Math break
 animefenix.com#$#abort-current-inline-script document.createElement _yzvesi
 pelisplus.so#$#abort-on-property-write _zoxxpiee
 iguarras.com,iputitas.net#$#abort-on-property-read afScript
-comicsporno.xxx#$#abort-current-inline-script document.querySelectorAll popMagic
+comicsporno.xxx,pornoreino.com#$#abort-current-inline-script document.querySelectorAll popMagic

--- a/spanish.txt
+++ b/spanish.txt
@@ -26,4 +26,4 @@ jkanime.net#$#abort-current-inline-script Math break
 animefenix.com#$#abort-current-inline-script document.createElement _yzvesi
 pelisplus.so#$#abort-on-property-write _zoxxpiee
 iguarras.com,iputitas.net#$#abort-on-property-read afScript
-comicsporno.xxx,felizporno.com,pornoreino.com#$#abort-current-inline-script document.querySelectorAll popMagic
+comicsporno.xxx,felizporno.com,mespornogratis.com,pornoreino.com#$#abort-current-inline-script document.querySelectorAll popMagic

--- a/spanish.txt
+++ b/spanish.txt
@@ -26,4 +26,4 @@ jkanime.net#$#abort-current-inline-script Math break
 animefenix.com#$#abort-current-inline-script document.createElement _yzvesi
 pelisplus.so#$#abort-on-property-write _zoxxpiee
 iguarras.com,iputitas.net#$#abort-on-property-read afScript
-comicsporno.xxx,pornoreino.com#$#abort-current-inline-script document.querySelectorAll popMagic
+comicsporno.xxx,felizporno.com,pornoreino.com#$#abort-current-inline-script document.querySelectorAll popMagic

--- a/spanish.txt
+++ b/spanish.txt
@@ -26,4 +26,4 @@ jkanime.net#$#abort-current-inline-script Math break
 animefenix.com#$#abort-current-inline-script document.createElement _yzvesi
 pelisplus.so#$#abort-on-property-write _zoxxpiee
 iguarras.com,iputitas.net#$#abort-on-property-read afScript
-comicsporno.xxx
+comicsporno.xxx#$#abort-current-inline-script document.querySelectorAll popMagic


### PR DESCRIPTION
Inline script responsible for popunders

Proposed filter: `comicsporno.xxx#$#abort-current-inline-script document.querySelectorAll popMagic`

Screenshot:
<img width="925" alt="Screenshot 2021-11-29 at 14 35 32" src="https://user-images.githubusercontent.com/65717387/143878186-2e27ec01-5a2c-48c3-bcee-e420bc30f204.png">
