### PR TITLE
MISC #738

### DIFF
--- a/spanish.txt
+++ b/spanish.txt
@@ -27,3 +27,4 @@ animefenix.com#$#abort-current-inline-script document.createElement _yzvesi
 pelisplus.so#$#abort-on-property-write _zoxxpiee
 iguarras.com,iputitas.net#$#abort-on-property-read afScript
 comicsporno.xxx,pornoreino.com,mespornogratis.com,felizporno.com,orgasmatrix.com,pornocolombiano.net#$#abort-current-inline-script document.querySelectorAll popMagic
+series-de.online#$#abort-on-property-read doSecondPop; abort-on-property-read doSecondPopU


### PR DESCRIPTION
Block popups/popunders at [series-de.online](https://series-de.online/episodio/csi-vegas-1x2/)

`series-de.online#$#abort-on-property-read doSecondPop; abort-on-property-read doSecondPopU`

Screenshot:
<img width="1280" alt="Screenshot 2021-12-08 at 07 07 51" src="https://user-images.githubusercontent.com/65717387/145157198-3489c38f-6c73-46ec-b184-ffe3019bd728.png">
<img width="799" alt="Screenshot 2021-12-08 at 07 07 27" src="https://user-images.githubusercontent.com/65717387/145157207-8a435f46-50d0-4545-92af-739c1ae46551.png">
<img width="833" alt="Screenshot 2021-12-08 at 07 07 14" src="https://user-images.githubusercontent.com/65717387/145157208-da221319-6db1-4848-b5c1-8079f1be89c2.png">

PS: to avoid console to clean the data use the following filters: 
```
||lspzhtvstux.com^
||katukaunamiss.com^
||walkinghonoured.com^
||dwayaihthfwvu.top^
```