### PR TITLE
czech.txt: remove rule

### DIFF
--- a/czech.txt
+++ b/czech.txt
@@ -513,7 +513,6 @@ karaoketexty.cz#$#hide-if-matches-xpath './/a[string-length(@href) >120][@target
 ||www.karaoketexty.cz/*/*.jpg$domain=karaoketexty.cz,rewrite=abp-resource:2x2-transparent-png
 
 novinky.cz#$#hide-if-matches-xpath '//a[@href][@title]/div[@class][@style]/parent::a/ancestor-or-self::div[2]'
-horoskopy.cz,novinky.cz,seznamzpravy.cz#$#hide-if-matches-xpath '//iframe[@src][@id]/parent::div[@class]/ancestor-or-self::div[@class][3]'
 
 ! #CV-780
 .cz/*,,*,|$xmlhttprequest,domain=auto.cz|autorevue.cz|maminka.cz|reflex.cz|ahaonline.cz|blesk.cz|dama.cz|e15.cz|info.cz|mobilmania.cz|mojezdravi.cz|onetv.cz|zeny.cz|zive.cz


### PR DESCRIPTION
Remove this rule that hides articles.

Due to this rule I cannot read many articles on seznamzpravy.cz or novinky.cz:
- https://www.seznamzpravy.cz/clanek/koronavirus-cesko-ma-druhy-potvrzeny-pripad-varianty-omikron-182871
- https://www.novinky.cz/zahranicni/svet/clanek/odstartoval-sojuz-s-japonskymi-vesmirnymi-turisty-40380445
- many more...

Adblock is blocking texts of these articles, I cannot read them. That makes me really unhappy.