### PR TITLE
A: MISC

### DIFF
--- a/english.txt
+++ b/english.txt
@@ -241,6 +241,7 @@ manganelo.tv#$#abort-on-property-read document.createElement
 manga18fx.com#$#abort-on-property-read Math.floor
 bangtubevideos.com#$#override-property-read setTimeout noopFunc; abort-on-property-write location.replace
 spankbang.com#$#abort-on-property-write window.open
+strikeout.cc#$#abort-current-inline-script document.createElement
 
 ! #CV-667
 gomovies.film,gomovies.sc,gomovies.es,gomovie.ms,gomovieshub.io,openloadmovies.net,openloadmovies.review,vidsrc.me,movies123.xyz,bonstreams.net,yts.am,keeplinks.co,flashx.pw,flashx.tv,cloudvideo.tv,gogoanime.cloud,revivelink.com#$#abort-on-property-read atob


### PR DESCRIPTION
Block popups on **strikeout.cc** when you click on any link or try to watch a video.
Some popups were blocked in EL EasyList.


Sample URLs: 
https://www.strikeout.cc/
https://www.strikeout.cc/football
