### PR TITLE
A: MISC

### DIFF
--- a/portuguese.txt
+++ b/portuguese.txt
@@ -11,6 +11,7 @@ topflix.fm#$#abort-current-inline-script String.fromCharCode XMLHttpRequest
 onifile.com#$#abort-on-property-read _pop
 pobtre.wtf##a[target="_blank"] > img[width="728"][height="90"]
 yayanimes.net#$#abort-current-inline-script document.createElement _wtxnqkt
+animesonline22.com#$#abort-current-inline-script JSON.parse /atob|btoa|break/
 
 ! #CV-667
 filmesonlinegratis.com#$#abort-current-inline-script Math zfgloaded


### PR DESCRIPTION
Popups come up when you click on any title and also manage the video controller; when you try to advance the video for example: https://www.animesonline22.com/video/189376

<img width="614" alt="r1" src="https://user-images.githubusercontent.com/57706597/165276278-772b7566-bac8-4e3e-bb18-24908fba0914.png">

<img width="744" alt="r3" src="https://user-images.githubusercontent.com/57706597/165276290-b70c98c8-1fa7-46b7-b9d3-a8f51c276095.png">

<img width="1005" alt="anime22b" src="https://user-images.githubusercontent.com/57706597/165276297-1a8719eb-42d1-42c0-96e1-eccd09e0ee00.png">

