### PR TITLE
A: MISC

### DIFF
--- a/english.txt
+++ b/english.txt
@@ -326,6 +326,7 @@ sxyprn.com#$#abort-current-inline-script vast_urls; override-property-read D4zz 
 123moviesgo.club#$#abort-on-property-write atAsyncContainers
 123moviesgo.club#$#abort-current-inline-script Math /break|case/
 pinayvids.com#$#abort-current-inline-script decodeURIComponent; override-property-read D4zz undefined
+eztv.tf,eztv.yt,yts.mx#$#abort-current-inline-script s2ss52
 
 *$popup,third-party,domain=streamega.com|123putlocker.club|openloadmovies.bz
 about:blank$popup,domain=streamtape.cc|streamtape.net|streamtape.xyz|streamtape.com|strtapeadblock.me|slreamplay.cc


### PR DESCRIPTION
**Issue:** Redirect popus on yts.mx eztv.tf and eztv.yt

- **yts.mx** - popups come up when you click on any item.

- **eztv.tf** and **eztv.yt** - popups come up when you click on any item and also on the video controller (try to advance the video for example).



**Reference PR:** https://github.com/easylist/easylist/pull/11800
Tried also to block the popups with: `/script/wait.php?q=$xmlhttprequest` and  `/script/nasu.js$third-party` but they don't seem enough still.

**Sample URLs and screenshots:**

https://yts.mx/movies/ambulance-2022
<img width="1236" alt="yts" src="https://user-images.githubusercontent.com/57706597/166232581-070ed9a3-e9ef-4a24-bfb7-b7e555391baa.png">

https://eztv.tf/ep/1789241/welcome-home-nikki-glaser-s01e02-can-we-talk-about-us-xvid-afg/
<img width="1209" alt="eztvTF" src="https://user-images.githubusercontent.com/57706597/166232552-9dc96c7d-38a9-4822-bc75-5e83027bcf9b.png">

https://eztv.yt/ep/1785750/61st-street-s01e04-1080p-hevc-x265-megusta/
<img width="1203" alt="eztvYT" src="https://user-images.githubusercontent.com/57706597/166232564-ee1ec99d-e4b1-40d7-a33c-131185d04ae2.png">
